### PR TITLE
[fontconfig]: Add inspec tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.fontconfig?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # fontconfig
 
 Fontconfig is a library for configuring and

--- a/README.md
+++ b/README.md
@@ -1,18 +1,114 @@
-[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.fontconfig?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.fontconfig?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=150&branchName=master)
 
 # fontconfig
 
-Fontconfig is a library for configuring and
-  customizing font access.
+Fontconfig is a library for configuring and customizing font access.  See [documentation](https://www.freedesktop.org/wiki/Software/fontconfig/)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/fontconfig as a dependency, you can add one of the following to your plan file.
+
+##### Buildtime Dependency
+
+> pkg_build_deps=(core/fontconfig)
+
+##### Runtime dependency
+
+> pkg_deps=(core/fontconfig)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/fontconfig --binlink``
+
+will add the following binaries to the PATH:
+
+* /bin/fc-cache
+* /bin/fc-cat
+* /bin/fc-list
+* /bin/fc-match
+* /bin/fc-pattern
+* /bin/fc-query
+* /bin/fc-scan
+* /bin/fc-validate
+
+For example:
+
+```bash
+$ hab pkg install core/fontconfig --binlink
+» Installing core/fontconfig
+☁ Determining latest version of core/fontconfig in the 'stable' channel
+↓ Downloading core/fontconfig/2.11.95/20200319210705
+    705.94 KB / 705.94 KB | [=====] 100.00 % 11.85 MB/s 
+☛ Verifying core/fontconfig/2.11.95/20200319210705
+→ Using core/acl/2.2.53/20200305230628
+→ Using core/attr/2.4.48/20200305230504
+→ Using core/bash/5.0.16/20200305233030
+→ Using core/bzip2/1.0.8/20200305225842
+→ Using core/coreutils/8.30/20200305231640
+→ Using core/expat/2.2.7/20200305234221
+☛ Verifying core/freetype/2.9.1/20200319191834
+→ Using core/gcc-libs/9.1.0/20200305225533
+→ Using core/glibc/2.29/20200305172459
+→ Using core/gmp/6.1.2/20200305175803
+→ Using core/libcap/2.27/20200305230759
+☛ Verifying core/libpng/1.6.37/20200310022515
+→ Using core/linux-headers/4.19.62/20200305172241
+→ Using core/ncurses/6.1/20200305230210
+☛ Verifying core/pkg-config/0.29.2/20200305230004
+→ Using core/readline/8.0/20200305232850
+→ Using core/sed/4.5/20200305230928
+→ Using core/zlib/1.2.11/20200305174519
+✓ Installed core/freetype/2.9.1/20200319191834
+✓ Installed core/libpng/1.6.37/20200310022515
+✓ Installed core/pkg-config/0.29.2/20200305230004
+✓ Installed core/fontconfig/2.11.95/20200319210705
+★ Install of core/fontconfig/2.11.95/20200319210705 complete with 4 new packages installed.
+» Binlinking fc-validate from core/fontconfig/2.11.95/20200319210705 into /bin
+★ Binlinked fc-validate from core/fontconfig/2.11.95/20200319210705 to /bin/fc-validate
+» Binlinking fc-cat from core/fontconfig/2.11.95/20200319210705 into /bin
+★ Binlinked fc-cat from core/fontconfig/2.11.95/20200319210705 to /bin/fc-cat
+» Binlinking fc-pattern from core/fontconfig/2.11.95/20200319210705 into /bin
+★ Binlinked fc-pattern from core/fontconfig/2.11.95/20200319210705 to /bin/fc-pattern
+» Binlinking fc-list from core/fontconfig/2.11.95/20200319210705 into /bin
+★ Binlinked fc-list from core/fontconfig/2.11.95/20200319210705 to /bin/fc-list
+» Binlinking fc-query from core/fontconfig/2.11.95/20200319210705 into /bin
+★ Binlinked fc-query from core/fontconfig/2.11.95/20200319210705 to /bin/fc-query
+» Binlinking fc-scan from core/fontconfig/2.11.95/20200319210705 into /bin
+★ Binlinked fc-scan from core/fontconfig/2.11.95/20200319210705 to /bin/fc-scan
+» Binlinking fc-match from core/fontconfig/2.11.95/20200319210705 into /bin
+★ Binlinked fc-match from core/fontconfig/2.11.95/20200319210705 to /bin/fc-match
+» Binlinking fc-cache from core/fontconfig/2.11.95/20200319210705 into /bin
+★ Binlinked fc-cache from core/fontconfig/2.11.95/20200319210705 to /bin/fc-cache
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/fc-list --help`` or ``fc-list --help``
+
+```bash
+$ fc-list --help
+usage: fc-list [-vqVh] [-f FORMAT] [--verbose] [--format=FORMAT] [--quiet] [--version] [--help] [pattern] {element ...} 
+List fonts matching [pattern]
+
+  -v, --verbose        display entire font pattern verbosely
+  -f, --format=FORMAT  use the given output format
+  -q, --quiet          suppress all normal output, exit 1 if no fonts matched
+  -V, --version        display font config version and exit
+  -h, --help           display this help and exit
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# fontconfig
+
+Fontconfig is a library for configuring and
+  customizing font access.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,2 @@
+plan_name: 'fontconfig'
 command_relative_path: 'bin/fc-list'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: 'bin/fc-list'

--- a/controls/fontconfig_exists.rb
+++ b/controls/fontconfig_exists.rb
@@ -1,0 +1,24 @@
+title 'Tests to confirm fontconfig exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'fontconfig')
+
+control 'core-plans-fontconfig-exists' do
+  impact 1.0
+  title 'Ensure fontconfig exists'
+  desc '
+  Verify fontconfig by ensuring bin/fc-list exists'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: 'bin/fc-list')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/fontconfig_exists.rb
+++ b/controls/fontconfig_exists.rb
@@ -17,8 +17,9 @@ control 'core-plans-fontconfig-exists' do
   end
 
   command_relative_path = input('command_relative_path', value: 'bin/fc-list')
-  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  command_full_path = File.join(plan_installation_directory.stdout.strip, command_relative_path)
   describe file(command_full_path) do
     it { should exist }
+    it { should be_executable }
   end
 end

--- a/controls/fontconfig_works.rb
+++ b/controls/fontconfig_works.rb
@@ -7,9 +7,9 @@ control 'core-plans-fontconfig-works' do
   impact 1.0
   title 'Ensure fontconfig works as expected'
   desc '
-  Verify fontconfig by ensuring 
-  (1) its installation directory exists and 
-  (2) that it returns the expected version.
+  Verify fontconfig by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -19,8 +19,8 @@ control 'core-plans-fontconfig-works' do
     its('stderr') { should be_empty }
   end
   
-  command_relative_path = input('command_relative_path', value: 'bin/fc-list')
-  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  command_relative_path = input('command_relative_path', value: 'bin/fontconfig')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, command_relative_path)
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
   describe command("#{command_full_path} --version") do
     its('exit_status') { should eq 0 }

--- a/controls/fontconfig_works.rb
+++ b/controls/fontconfig_works.rb
@@ -1,0 +1,31 @@
+title 'Tests to confirm fontconfig works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'fontconfig')
+
+control 'core-plans-fontconfig-works' do
+  impact 1.0
+  title 'Ensure fontconfig works as expected'
+  desc '
+  Verify fontconfig by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  command_relative_path = input('command_relative_path', value: 'bin/fc-list')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should_not be_empty }
+    its('stderr') { should match /fontconfig version #{plan_pkg_version}/ }
+    its('stdout') { should be_empty }
+  end
+end

--- a/glibc-2.25+.patch
+++ b/glibc-2.25+.patch
@@ -1,0 +1,72 @@
+From 20cddc824c6501c2082cac41b162c34cd5fcc530 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 11 Dec 2016 14:32:00 -0800
+Subject: [PATCH] Avoid conflicts with integer width macros from TS
+ 18661-1:2014
+
+glibc 2.25+ has now defined these macros in <limits.h>
+https://sourceware.org/git/?p=glibc.git;a=commit;h=5b17fd0da62bf923cb61d1bb7b08cf2e1f1f9c1a
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+Upstream-Status: Submitted
+
+ fontconfig/fontconfig.h | 2 +-
+ src/fcobjs.h            | 2 +-
+ src/fcobjshash.gperf    | 2 +-
+ src/fcobjshash.h        | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+Index: fontconfig-2.12.1/fontconfig/fontconfig.h
+===================================================================
+--- fontconfig-2.12.1.orig/fontconfig/fontconfig.h
++++ fontconfig-2.12.1/fontconfig/fontconfig.h
+@@ -128,7 +128,8 @@ typedef int		FcBool;
+ #define FC_USER_CACHE_FILE	    ".fonts.cache-" FC_CACHE_VERSION
+ 
+ /* Adjust outline rasterizer */
+-#define FC_CHAR_WIDTH	    "charwidth"	/* Int */
++#define FC_CHARWIDTH	    "charwidth"	/* Int */
++#define FC_CHAR_WIDTH	    FC_CHARWIDTH
+ #define FC_CHAR_HEIGHT	    "charheight"/* Int */
+ #define FC_MATRIX	    "matrix"    /* FcMatrix */
+ 
+Index: fontconfig-2.12.1/src/fcobjs.h
+===================================================================
+--- fontconfig-2.12.1.orig/src/fcobjs.h
++++ fontconfig-2.12.1/src/fcobjs.h
+@@ -51,7 +51,7 @@ FC_OBJECT (DPI,			FcTypeDouble,	NULL)
+ FC_OBJECT (RGBA,		FcTypeInteger,	NULL)
+ FC_OBJECT (SCALE,		FcTypeDouble,	NULL)
+ FC_OBJECT (MINSPACE,		FcTypeBool,	NULL)
+-FC_OBJECT (CHAR_WIDTH,		FcTypeInteger,	NULL)
++FC_OBJECT (CHARWIDTH,		FcTypeInteger,	NULL)
+ FC_OBJECT (CHAR_HEIGHT,		FcTypeInteger,	NULL)
+ FC_OBJECT (MATRIX,		FcTypeMatrix,	NULL)
+ FC_OBJECT (CHARSET,		FcTypeCharSet,	FcCompareCharSet)
+Index: fontconfig-2.12.1/src/fcobjshash.gperf
+===================================================================
+--- fontconfig-2.12.1.orig/src/fcobjshash.gperf
++++ fontconfig-2.12.1/src/fcobjshash.gperf
+@@ -44,7 +44,7 @@ int id;
+ "rgba",FC_RGBA_OBJECT
+ "scale",FC_SCALE_OBJECT
+ "minspace",FC_MINSPACE_OBJECT
+-"charwidth",FC_CHAR_WIDTH_OBJECT
++"charwidth",FC_CHARWIDTH_OBJECT
+ "charheight",FC_CHAR_HEIGHT_OBJECT
+ "matrix",FC_MATRIX_OBJECT
+ "charset",FC_CHARSET_OBJECT
+Index: fontconfig-2.12.1/src/fcobjshash.h
+===================================================================
+--- fontconfig-2.12.1.orig/src/fcobjshash.h
++++ fontconfig-2.12.1/src/fcobjshash.h
+@@ -284,7 +284,7 @@ FcObjectTypeLookup (register const char
+       {(int)(long)&((struct FcObjectTypeNamePool_t *)0)->FcObjectTypeNamePool_str43,FC_CHARSET_OBJECT},
+       {-1},
+ #line 47 "fcobjshash.gperf"
+-      {(int)(long)&((struct FcObjectTypeNamePool_t *)0)->FcObjectTypeNamePool_str45,FC_CHAR_WIDTH_OBJECT},
++      {(int)(long)&((struct FcObjectTypeNamePool_t *)0)->FcObjectTypeNamePool_str45,FC_CHARWIDTH_OBJECT},
+ #line 48 "fcobjshash.gperf"
+       {(int)(long)&((struct FcObjectTypeNamePool_t *)0)->FcObjectTypeNamePool_str46,FC_CHAR_HEIGHT_OBJECT},
+ #line 55 "fcobjshash.gperf"

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,7 @@
 name: fontconfig
 title: Habitat Core Plan fontconfig
-maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+maintainer: "The Core Planners <chef-core-planners@chef.io>"
 summary: InSpec controls for testing Habitat Core Plan fontconfig
-copyright: 2019, Chef Software, Inc.
-copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
-inspec_version: '>= 3.0.25'
+inspec_version: '>= 4.18.108'

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: fontconfig
+title: Habitat Core Plan fontconfig
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan fontconfig
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,71 @@
+pkg_name=fontconfig
+pkg_version=2.11.95
+pkg_origin=core
+pkg_license=('fontconfig')
+pkg_description="Fontconfig is a library for configuring and customizing font access."
+pkg_upstream_url=https://www.freedesktop.org/wiki/Software/fontconfig/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://www.freedesktop.org/software/fontconfig/release/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=7b165eee7aa22dcc1557db56f58d905b6a14b32f9701c79427452474375b4c89
+pkg_deps=(
+  core/bzip2
+  core/glibc
+  core/zlib
+  core/freetype
+  core/libpng
+  core/expat
+  core/gcc-libs
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/coreutils
+  core/python
+  core/pkg-config
+  core/diffutils
+  core/libtool
+  core/m4
+  core/automake
+  core/autoconf
+  core/file
+  core/patch
+)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+  # Set freetype paths
+  export FREETYPE_CFLAGS="${CFLAGS}"
+  build_line "Setting FREETYPE_CFLAGS=${FREETYPE_CFLAGS}"
+  export FREETYPE_LIBS
+  FREETYPE_LIBS="${LDFLAGS} -Wl,--rpath -Wl,$(pkg_path_for freetype)/lib -lfreetype -lz"
+  build_line "Setting FREETYPE_LIBS=${FREETYPE_LIBS}"
+
+  # Add "freetype2" to include path
+  export CFLAGS
+  CFLAGS="${CFLAGS} -I$(pkg_path_for freetype)/include/freetype2"
+  build_line "Setting CFLAGS=${CFLAGS}"
+
+  # Borrowing this pro tip from ArchLinux!
+  # https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/fontconfig#n34
+  # this seems to run libtoolize though...
+  autoreconf -fi
+
+  _file_path="$(pkg_path_for file)/bin/file"
+  _uname_path="$(pkg_path_for coreutils)/bin/uname"
+
+  sed -e "s#/usr/bin/file#${_file_path}#g" -i configure
+  sed -e "s#/usr/bin/uname#${_uname_path}#g" -i configure
+
+  patch -p1 < "${PLAN_CONTEXT}/glibc-2.25+.patch"
+}
+
+do_build() {
+  ./configure \
+    --sysconfdir="${pkg_prefix}/etc" \
+    --prefix="${pkg_prefix}" \
+    --disable-static \
+    --mandir="${pkg_prefix}/man"
+  make
+}


### PR DESCRIPTION


```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://35b645b7a43ab8a9667dc140e38bb6fc065f85e8f15bd808b6e28242d784d1f8 --input-file /src/attributes.yml

Profile: Habitat Core Plan fontconfig (fontconfig)
Version: 0.1.0
Target:  docker://35b645b7a43ab8a9667dc140e38bb6fc065f85e8f15bd808b6e28242d784d1f8

  ✔  core-plans-fontconfig-works: Ensure fontconfig works as expected
     ✔  Command: `hab pkg path core/fontconfig` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/fontconfig` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/fontconfig` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/fontconfig/2.11.95/20200612163428/bin/fc-list --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/fontconfig/2.11.95/20200612163428/bin/fc-list --version` stderr is expected not to be empty
     ✔  Command: `/hab/pkgs/core/fontconfig/2.11.95/20200612163428/bin/fc-list --version` stderr is expected to match /fontconfig version 2.11.95/
     ✔  Command: `/hab/pkgs/core/fontconfig/2.11.95/20200612163428/bin/fc-list --version` stdout is expected to be empty
  ✔  core-plans-fontconfig-exists: Ensure fontconfig exists
     ✔  Command: `hab pkg path core/fontconfig` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/fontconfig` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/fontconfig` stderr is expected to be empty
     ✔  File /hab/pkgs/core/fontconfig/2.11.95/20200612163428/bin/fc-list is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 11 successful, 0 failures, 0 skipped
+ set +x
[20][default:/src:0]# 
```